### PR TITLE
Enable image name to prevent issues if new uploaded images

### DIFF
--- a/tf/image.tf
+++ b/tf/image.tf
@@ -1,9 +1,9 @@
 data "openstack_images_image_v2" "vgcn-image" {
-  //name = "${var.image["name"]}"
+  name = "${var.image["name"]}"
   most_recent = true
 }
 
 data "openstack_images_image_v2" "vgcn-image-gpu" {
-  //name = "${var.gpu_image["name"]}"
+  name = "${var.gpu_image["name"]}"
   most_recent = true
 }


### PR DESCRIPTION
If the image name is commented, the last uploaded image on glance will be used. If this is different, i.e. not the vgcn image, this will cause problems. This PR is for fixing this behaviour.