### PR TITLE
bug: Add missing DNS entries to internal network.

### DIFF
--- a/tf/int_network.tf
+++ b/tf/int_network.tf
@@ -9,6 +9,7 @@ resource "openstack_networking_subnet_v2" "internal" {
   cidr        = var.private_network["cidr4"]
   ip_version  = 4
   enable_dhcp = true
+  dns_nameservers = ["1.1.1.1","1.0.0.1","8.8.8.8"]
 }
 
 resource "openstack_networking_router_v2" "router_1" {


### PR DESCRIPTION
This commit adds DNS servers to internal network during creation, allowing VMs behind NAT to be able to resolve hosts without manual configuration.

With this change, this TF+Ansible playbook can be deployed to create a working infrastructure with no configuration beyond `vars.tf` file.

--Hakan

**P.S.:** Adding @mtangaro for visibility.