### PR TITLE
HTCondor 24.x and minor improvements

### DIFF
--- a/tf/ansible/main.yml
+++ b/tf/ansible/main.yml
@@ -38,7 +38,7 @@
   roles:
     - role: ansible-htcondor-grycap
       vars:
-        htcondor_version: "23.x"
+        htcondor_version: "24.x"
         htcondor_type_of_node: "front"
         htcondor_role_manager: true
         htcondor_role_submit: true

--- a/tf/ansible/main.yml
+++ b/tf/ansible/main.yml
@@ -38,7 +38,7 @@
   roles:
     - role: ansible-htcondor-grycap
       vars:
-        htcondor_version: "10.x"
+        htcondor_version: "23.x"
         htcondor_type_of_node: "front"
         htcondor_role_manager: true
         htcondor_role_submit: true

--- a/tf/ansible/main.yml
+++ b/tf/ansible/main.yml
@@ -2,8 +2,20 @@
 - name: Install HTCondor Central Manager on Pulsar
   become: yes
   hosts: all
+  gather_facts: false
 
   pre_tasks:
+    - name: Wait for SSH to be ready
+      ansible.builtin.wait_for_connection:
+        delay: 60
+        timeout: 600
+        connect_timeout: 5
+        sleep: 60
+      when: tf_var_check | default(false)
+
+    - name: Gather Facts
+      ansible.builtin.setup:
+
     - name: Install or upgrade Pulsar package
       ansible.builtin.pip:
         name: pulsar-app

--- a/tf/exec_nodes.tf
+++ b/tf/exec_nodes.tf
@@ -72,7 +72,7 @@ resource "openstack_compute_instance_v2" "exec-node" {
           roles:
             - name: ansible-htcondor-grycap
               vars:
-                htcondor_version: 23.x
+                htcondor_version: 24.x
                 htcondor_type_of_node: wn
                 htcondor_role_execute: true
                 htcondor_server: ${openstack_compute_instance_v2.central-manager.network.1.fixed_ip_v4}

--- a/tf/exec_nodes.tf
+++ b/tf/exec_nodes.tf
@@ -72,7 +72,7 @@ resource "openstack_compute_instance_v2" "exec-node" {
           roles:
             - name: ansible-htcondor-grycap
               vars:
-                htcondor_version: 10.x
+                htcondor_version: 23.x
                 htcondor_type_of_node: wn
                 htcondor_role_execute: true
                 htcondor_server: ${openstack_compute_instance_v2.central-manager.network.1.fixed_ip_v4}

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -16,7 +16,6 @@ resource "openstack_compute_instance_v2" "central-manager" {
   provisioner "local-exec" {
     command = <<-EOF
       ansible-galaxy install -p ansible/roles -r ansible/requirements.yml
-      sleep 450
         ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u centos -b -i '${self.access_ip_v4},' \
         --private-key ${var.pvt_key} --extra-vars='condor_ip_range=${var.private_network.cidr4}  
         htcondor_server=${self.network.1.fixed_ip_v4} htcondor_password=${var.condor_pass}

--- a/tf/vars.tf
+++ b/tf/vars.tf
@@ -28,9 +28,9 @@ variable "gpu_node_count" {
 variable "image" {
   type = map(any)
   default = {
-//  "name"             = "vggp-v60-j225-1a1df01ec8f3-dev"
+//  "name"             = "vgcn-rockylinux-9-generic-workers-external~20250604~28332~pxe~b3a17c9"
     "name"             = "<name for that image>"
-//  "image_source_url" = "https://usegalaxy.eu/static/vgcn/vggp-v60-j225-1a1df01ec8f3-dev.raw"
+//  "image_source_url" = "https://usegalaxy.eu/static/vgcn/vgcn~rockylinux-9-latest-x86_64~%2Bgeneric%2Bworkers%2Bexternal~20250604~28332~pxe~b3a17c9.raw"
     "image_source_url" = "<url-to-latest-vgcn-image>"
     // you can check for the latest image on https://usegalaxy.eu/static/vgcn/ and replace this
     "container_format" = "bare"
@@ -114,7 +114,7 @@ variable "mq_string" {}
 // Set the extra_mq_urls variable to deploy multiple pulsar services. Leave unedited otherwise
 // Example: terraform apply -var "pvt_key=<~/.ssh/my_private_key>" 
 // -var "condor_pass=<MyCondorPassword>" 
-// -var "condor_pass=pyamqp://<your-rabbit-mq-user>:<the-password-we-provided-to-you>@mq.galaxyproject.eu:5671//pulsar/<your-rabbit-mq-vhost>?ssl=1"
+// -var "mq_string=pyamqp://<your-rabbit-mq-user>:<the-password-we-provided-to-you>@mq.galaxyproject.eu:5671//pulsar/<your-rabbit-mq-vhost>?ssl=1"
 // -var 'extra_mq_urls={it="pyamqp_url0", be="pyamqp_url1"}'
 
 variable "extra_mq_urls" {
@@ -132,11 +132,11 @@ variable "extra_mq_urls" {
   )
   error_message = "Extra message queues must not contain mq_string and values must be unique."
 }
-} 
+}
 
 // Pass an empty map if extra_mq_urls is unedited, otherwise wraps the map with the ansible dictionary name
 locals {
   norm_ex_mqs = ( 
-    tomap({"name" = "value"}) == var.extra_mq_urls 
+    tomap({"name" = "value"}) == var.extra_mq_urls
     ) ? tomap({}) : merge(tomap({"ex_mqs_dict" = var.extra_mq_urls}))
 }


### PR DESCRIPTION
## Summary

Update HTCondor and improve the timing between central manager provisioning and the execution of the `local-exec` resource used to launch the playbook.

## Changes

* Upgraded `htcondor_version` from 10.x (deprecated) to 24.x;
* Replaced the `sleep 450` in `tf/main.tf` with the `ansible.builtin.wait_for_connection` pre-task:

  * When `tf/ansible/main.yml` is run manually, it behaves as usual unless `tf_var_check` is set to `true`;
  * Facts are gathered only after a successful connection, so any additional pre-tasks that act on the host must be added after the `ansible.builtin.setup` pre-task;
  * Connection attempts timeout after 5 seconds. Retries occur every 60 seconds, with a total allowed duration of 10 minutes. The 60-second buffer also applies before the first attempt.
	
* Replaced the CPU image source URL comment with the [latest VGCN image URL](https://usegalaxy.eu/static/vgcn/vgcn~rockylinux-9-latest-x86_64~%2Bgeneric%2Bworkers%2Bexternal~20250604~28332~pxe~b3a17c9.raw), which works "out of the box" without requiring Ansible playbook modifications.
* Minor comments improvements.

## Related Issues

Closes #24 
Relates to #26 

## Notes

@mtangaro is working on a PR to update the HTCondor role for version 24.x. In the meantime, these changes remain compatible with version 23.x, setting `htcondor_version` to 23.x in the playbooks is sufficient. Make sure to use the last version of the role.

I tested the changes related to the sleep time while working with various VGCN images and upgrading HTCondor. The redeployment of the `it-pulsar` endpoint (RECAS) worked flawlessly. A temporary Pulsar endpoint deployed on a different infrastructure provider, with the timing changes, also worked without issues.

Regarding older images:

* When deploying newer HTCondor versions (>10.x), it may be necessary to upgrade all packages via a pre-task before running the HTCondor role. This should be done both in `tf/ansible/main.yml` and in the playbook within the cloud-init configuration in `tf/exec_nodes.tf`.
* For the [vggp-v60-j340-e3937ea797ed-dev](https://usegalaxy.eu/static/vgcn/vggp-v60-j340-e3937ea797ed-dev.raw) image, an additional fix is required as noted in issue #26.

